### PR TITLE
Added industry and technology used to projects/project page

### DIFF
--- a/repoData.json
+++ b/repoData.json
@@ -58,8 +58,14 @@
               }
             ]
           },
-          "industry": "Unspecified",
+          "industry": "Insurance",
           "publish": "True",
+          "technology": [
+            "Security Verify",
+            "Watsonx Orchestrate",
+            "watsonx.ai",
+            "watsonx.governance"
+          ],
           "title": "Unified Virtual Agent"
         },
         {
@@ -85,8 +91,13 @@
               }
             ]
           },
-          "industry": "Unspecified",
+          "industry": "Various",
           "publish": "True",
+          "technology": [
+            "Watson Discovery",
+            "Watsonx Assistant",
+            "watsonx.ai"
+          ],
           "title": "AI Assistants"
         },
         {
@@ -123,8 +134,12 @@
               }
             ]
           },
-          "industry": "Unspecified",
+          "industry": "Various",
           "publish": "True",
+          "technology": [
+            "Openshift",
+            "watsonx.ai"
+          ],
           "title": "IBM watsonx.ai on AWS"
         },
         {
@@ -227,8 +242,11 @@
               }
             ]
           },
-          "industry": "Unspecified",
+          "industry": "Insurance",
           "publish": "True",
+          "technology": [
+            "FileNet"
+          ],
           "title": "FileNet Content Manager on AWS EKS "
         },
         {
@@ -388,8 +406,12 @@
               }
             ]
           },
-          "industry": "Unspecified",
+          "industry": "Various",
           "publish": "True",
+          "technology": [
+            "Watsonx Orchestrate",
+            "watsonx.ai"
+          ],
           "title": "Watsonx Orchestrate Integrations"
         },
         {
@@ -410,8 +432,12 @@
               }
             ]
           },
-          "industry": "Unspecified",
+          "industry": "Finance",
           "publish": "True",
+          "technology": [
+            "Openshift",
+            "Process Mining"
+          ],
           "title": "Process Mining on Red Hat OpenShift"
         },
         {
@@ -477,8 +503,11 @@
               }
             ]
           },
-          "industry": "Unspecified",
+          "industry": "Finance",
           "publish": "True",
+          "technology": [
+            "Sterling File Gateway"
+          ],
           "title": "Sterling File Gateway on AWS EKS"
         },
         {
@@ -499,8 +528,12 @@
               }
             ]
           },
-          "industry": "Unspecified",
+          "industry": "Banking",
           "publish": "True",
+          "technology": [
+            "IBM Cloud Satellite",
+            "Terraform"
+          ],
           "title": "IBM Satellite on IBM Cloud and AWS"
         },
         {
@@ -521,8 +554,12 @@
               }
             ]
           },
-          "industry": "Unspecified",
+          "industry": "Banking",
           "publish": "True",
+          "technology": [
+            "Ansible",
+            "Aspera"
+          ],
           "title": "Aspera Install Using Ansible Playbooks"
         },
         {
@@ -548,8 +585,11 @@
               }
             ]
           },
-          "industry": "Unspecified",
+          "industry": "Various",
           "publish": "True",
+          "technology": [
+            "Watsonx Orchestrate"
+          ],
           "title": "AWS Lambda on Watson Orchestrate"
         },
         {
@@ -565,8 +605,11 @@
               }
             ]
           },
-          "industry": "Unspecified",
+          "industry": "Various",
           "publish": "True",
+          "technology": [
+            "CP4BA"
+          ],
           "title": "Automated Document Processing"
         },
         {

--- a/src/app/projects/ProjectsTiles.js
+++ b/src/app/projects/ProjectsTiles.js
@@ -23,12 +23,6 @@ const ProjectsTiles = ({ data }) => {
               {tech}
             </Tag>
           )) : <></>}
-          </Row><Row className="project__row">
-          {repo.repositoryTopics.nodes.map((nodes, index) => (
-            <Tag className="projectTile__topics" key={index}>
-              {nodes.topic.name}
-            </Tag>
-          ))}
           </Row>
         </ClickableTile>
       ))}

--- a/src/app/projects/ProjectsTiles.js
+++ b/src/app/projects/ProjectsTiles.js
@@ -14,6 +14,13 @@ const ProjectsTiles = ({ data }) => {
         <ClickableTile id={repo.name} className="projectTile" key={index} href={repo.homepageUrl} target="_blank" rel="noopener noreferrer" renderIcon={Launch}>
           <h6 className="projectTile__title">{repo.title}</h6>
           <p3 className="projectTile__description">{repo.description}</p3>
+          { Object.hasOwn(repo, "technology") ? 
+          repo.technology.map((tech, index) => (
+            <Tag className="projectTile__techs" type="blue" key={index}>
+              {tech}
+            </Tag>
+          )) : <></>}
+          <br></br>
           {repo.repositoryTopics.nodes.map((nodes, index) => (
             <Tag className="projectTile__topics" key={index}>
               {nodes.topic.name}

--- a/src/app/projects/ProjectsTiles.js
+++ b/src/app/projects/ProjectsTiles.js
@@ -13,6 +13,7 @@ const ProjectsTiles = ({ data }) => {
       {data.map((repo, index) => (
         <ClickableTile id={repo.name} className="projectTile" key={index} href={repo.homepageUrl} target="_blank" rel="noopener noreferrer" renderIcon={Launch}>
           <h6 className="projectTile__title">{repo.title}</h6>
+          <p3 className="projectTile__industry">{repo.industry}</p3>
           <p3 className="projectTile__description">{repo.description}</p3>
           { Object.hasOwn(repo, "technology") ? 
           repo.technology.map((tech, index) => (

--- a/src/app/projects/ProjectsTiles.js
+++ b/src/app/projects/ProjectsTiles.js
@@ -1,10 +1,10 @@
 'use client';
-
 import React from 'react';
-import { Launch } from '@carbon/icons-react';
+import { Launch, ToolKit } from '@carbon/icons-react';
 import {
   ClickableTile,
   Tag,
+  Row,
 } from "@carbon/react";
 
 const ProjectsTiles = ({ data }) => {
@@ -15,18 +15,21 @@ const ProjectsTiles = ({ data }) => {
           <h6 className="projectTile__title">{repo.title}</h6>
           <p3 className="projectTile__industry">{repo.industry}</p3>
           <p3 className="projectTile__description">{repo.description}</p3>
+          <Row className="project__row">
+          <ToolKit className="toolkit_icon"/>
           { Object.hasOwn(repo, "technology") ? 
           repo.technology.map((tech, index) => (
             <Tag className="projectTile__techs" type="blue" key={index}>
               {tech}
             </Tag>
           )) : <></>}
-          <br></br>
+          </Row><Row className="project__row">
           {repo.repositoryTopics.nodes.map((nodes, index) => (
             <Tag className="projectTile__topics" key={index}>
               {nodes.topic.name}
             </Tag>
           ))}
+          </Row>
         </ClickableTile>
       ))}
     </div>

--- a/src/app/projects/_projects-page.scss
+++ b/src/app/projects/_projects-page.scss
@@ -42,7 +42,7 @@
     border: 1px solid var(--UI-ui-03, #E0E0E0);
     background: #FFF;
     width: 300px;
-    height: 250px;
+    height: 350px;
   }
 
 .projectTile__title {
@@ -53,6 +53,15 @@
     align-items: flex-start;
     gap: 8px;
     align-self: stretch;
+}
+
+.projectTile__industry {
+    display: flex;
+    //padding: 16px 16px 0px 0px;
+    flex-direction: column;
+    align-items: flex-start;
+    align-self: stretch;
+    font-style: italic;
 }
 
 .projectTile__description {

--- a/src/app/projects/_projects-page.scss
+++ b/src/app/projects/_projects-page.scss
@@ -84,6 +84,19 @@
     font-weight: bold;
 }
 
+.project__row {
+    padding: 0px 16px 0px 16px;
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.toolkit_icon {
+    margin-top: auto;
+    margin-bottom: auto;
+    margin-right: .5em;
+    margin-left: 0px;
+}
+
 .filter-search {
     width: 40%;
 }

--- a/src/app/projects/_projects-page.scss
+++ b/src/app/projects/_projects-page.scss
@@ -85,14 +85,18 @@
 }
 
 .filter-search {
-    width: 35%;
+    width: 40%;
 }
 
 .banner-search {
-    width: 65%;
+    width: 80%;
 }
 
 .search-row {
+    width: 100%;
+    padding-left: 1em;
+}
+.filter-row {
     width: 100%;
     padding-left: 1em;
 }

--- a/src/app/projects/_projects-page.scss
+++ b/src/app/projects/_projects-page.scss
@@ -98,11 +98,11 @@
 }
 
 .filter-search {
-    width: 40%;
+    width: 30%;
 }
 
 .banner-search {
-    width: 80%;
+    width: 70%;
 }
 
 .search-row {

--- a/src/app/projects/_projects-page.scss
+++ b/src/app/projects/_projects-page.scss
@@ -42,7 +42,7 @@
     border: 1px solid var(--UI-ui-03, #E0E0E0);
     background: #FFF;
     width: 300px;
-    height: 350px;
+    height: 300px;
   }
 
 .projectTile__title {

--- a/src/app/projects/_projects-page.scss
+++ b/src/app/projects/_projects-page.scss
@@ -47,6 +47,7 @@
 
 .projectTile__title {
     display: flex;
+    font-size: 1.25em;
     padding: 16px 32px 0px 0px;
     flex-direction: column;
     align-items: flex-start;
@@ -69,6 +70,10 @@
     justify-content: flex-start;
     gap: 16px;
   }
+
+.projectTile__techs {
+    font-weight: bold;
+}
 
 .filter-search {
     width: 35%;

--- a/src/app/projects/page.js
+++ b/src/app/projects/page.js
@@ -59,14 +59,20 @@ function ProjectsPage() {
     const inputText = e.target.value.toLowerCase();
     repoData.forEach((node) => {
       let inTopic = false;
+      let inTech = false;
       node.repositoryTopics.nodes.forEach((topic) => {
         if (topic.topic.name.toLowerCase().includes(inputText)) {
           inTopic = true;
         }
       });
+      node.technology?.forEach((tech) => {
+        if (tech.toLowerCase().includes(inputText)) {
+          inTech = true;
+        }
+      });
 
       const isVisible = 
-        inTopic ||
+        inTopic || inTech ||
         (node.name && node.name.toLowerCase().includes(inputText)) ||
         (node.description && node.description.toLowerCase().includes(inputText)) ||
         (node.title && node.title.toLowerCase().includes(inputText)) ||

--- a/src/app/projects/page.js
+++ b/src/app/projects/page.js
@@ -58,7 +58,8 @@ function ProjectsPage() {
         inTopic ||
         (node.name && node.name.toLowerCase().includes(inputText)) ||
         (node.description && node.description.toLowerCase().includes(inputText)) ||
-        (node.title && node.title.toLowerCase().includes(inputText));
+        (node.title && node.title.toLowerCase().includes(inputText)) ||
+        (node.industry && node.industry.toLowerCase().includes(inputText));
 
       if (document.getElementById(node.name)) {
         const temp = repoFiltered.get(node.name);

--- a/src/app/projects/page.js
+++ b/src/app/projects/page.js
@@ -19,18 +19,14 @@ repoData.forEach((node) => {
   //if the object has a technology field, add it to the techs set
   Object.hasOwn(node, "technology") ? node.technology.forEach((tech) => {techs.add(tech);}) : {};
 });
-const topicsArray = Array.from(topics);
 const techsArray = Array.from(techs);
 
 // Parse URL parameters outside the component
 const urlParams = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null;
-const topic = urlParams ? urlParams.get('topic') : null;
 const tech = urlParams ? urlParams.get('tech') : null;
-const initialSelectedTopics = topic ? [topic] : [];
 const initialSelectedTechs = tech ? [tech] : [];
 
 function ProjectsPage() {
-  const [selectedTopics, setSelectedTopics] = useState(initialSelectedTopics);
   const [selectedTechs, setSelectedTechs] = useState(initialSelectedTechs);
 
   // Define the renderProjects function, which updates the page based on the user inputted filters
@@ -45,13 +41,6 @@ function ProjectsPage() {
       }
     });
   };
-
-  // This function calls renderProjects initially to reflect initial selection
-  useEffect(() => {
-    if (topic) {
-      filterProjectsTopicGiven(topic);
-    }
-  }, [topic]);
 
   //take the search value and see if it matches (at least partially) the name, title, description, or industry
   //updates the repoFiltered object, and calls renderProjects()
@@ -87,23 +76,6 @@ function ProjectsPage() {
     renderProjects();
   };
 
-  //callback function for the topic filter, filters the projects by the topics selected
-  const filterProjectsTopic = (e) => {
-    const inputTopics = e.selectedItems;
-    setSelectedTopics(inputTopics);
-    repoData.forEach((node) => {
-      const nodeTopics = node.repositoryTopics.nodes.map((topic) => topic.topic.name);
-      const inRepo = inputTopics.every((topic) => nodeTopics.includes(topic));
-
-      if (document.getElementById(node.name)) {
-        const temp = repoFiltered.get(node.name);
-        temp.topic = inRepo;
-        repoFiltered.set(node.name, temp);
-      }
-    });
-    renderProjects();
-  };
-
     //callback function for the technology filter, filters the projects by the technologies selected
     const filterProjectsTech = (e) => {
       const inputTechs = e.selectedItems;
@@ -123,21 +95,6 @@ function ProjectsPage() {
       renderProjects();
     };
 
-  // used just for the case that there is a topic already selected (ie in the query)
-  const filterProjectsTopicGiven = (topic) => {
-    repoData.forEach((node) => {
-      const nodeTopics = node.repositoryTopics.nodes.map((topic) => topic.topic.name);
-      const inRepo = nodeTopics.includes(topic);
-
-      if (document.getElementById(node.name)) {
-        const temp = repoFiltered.get(node.name);
-        temp.topic = inRepo;
-        repoFiltered.set(node.name, temp);
-      }
-    });
-    renderProjects();
-  };
-
   return (
     <Grid fullWidth narrow>
       <Column className="banner-container" lg={16} md={8} sm={4}>
@@ -145,8 +102,6 @@ function ProjectsPage() {
           <p className="banner-title">Projects</p>
           <Row className='search-row'>
             <Search className="banner-search" size="lg" placeholder="Search" labelText="Search" closeButtonLabelText="Clear search input" onChange={searchProjects} />
-          </Row>
-          <Row className='filter-row'>
             <FilterableMultiSelect 
               id="carbon-multiselect" 
               className="filter-search" 
@@ -157,17 +112,6 @@ function ProjectsPage() {
               selectionFeedback="top-after-reopen" 
               onChange={filterProjectsTech} 
               initialSelectedItems={selectedTechs} // Set selected items based on state
-            />
-            <FilterableMultiSelect 
-              id="carbon-multiselect" 
-              className="filter-search" 
-              size="lg" 
-              placeholder="Topics" 
-              items={topicsArray} 
-              itemToString={item => item ? item : ''} 
-              selectionFeedback="top-after-reopen" 
-              onChange={filterProjectsTopic} 
-              initialSelectedItems={selectedTopics} // Set selected items based on state
             />
           </Row>
         </Column>


### PR DESCRIPTION
**User Story:**
I am a technical stakeholder at a company evaluating IBM products, I want to browse the Solutions Hub to discover real-world technical use cases where IBM products have been implemented in similar companies, so I can determine how these solutions align with my company’s needs and goals. This will help me decide if investing in IBM technology is worthwhile for my company.

**Acceptance Criteria:**
- The external Solutions Hub lists all repositories on the public Client Engineering GitHub
- Each repository includes the business background of the project and code
- Users can filter and sort projects by industry, IBM product
- Users can search the Solutions Hub by typing in a product name or a specific use case, and relevant projects will be displayed based on the entered search terms.
- For each project, it is clear what the business purpose and technologies used are.

<img width="1570" alt="Screenshot 2024-10-30 at 3 08 45 PM" src="https://github.com/user-attachments/assets/eac70864-a8e1-4148-8c43-302eda8c148f">

The industry is shown in italics below the project name and the technology used is a blue tag above the "topic" tags. If no industry is given, the system defaults to "Unspecified"

