### PR TITLE
Design rework

### DIFF
--- a/src/app/home/RecentProjectsTiles.js
+++ b/src/app/home/RecentProjectsTiles.js
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Launch, RecentlyViewed, ToolKit } from '@carbon/icons-react';
+import { Launch, RecentlyViewed, ToolKit, Enterprise } from '@carbon/icons-react';
 import {
   ClickableTile,
   Tag,
@@ -19,16 +19,19 @@ const RecentProjectsTiles = ({ data }) => {
           <ClickableTile id={repo.name} className="projectTile-home" key={index} href={repo.homepageUrl} target="_blank" rel="noopener noreferrer" renderIcon={Launch}>
           <RecentlyViewed size={32} />
           <h6 className="projectTile__title">{repo.title}</h6>
-          <p3 className="projectTile__industry">{repo.industry}</p3>
           <p3 className="projectTile__description">{repo.description}</p3>
           <Row className="project__row">
-          <ToolKit className="toolkit_icon"/>
-          { Object.hasOwn(repo, "technology") ? 
-          repo.technology.map((tech, index) => (
-            <Tag className="projectTile__techs" type="blue" key={index}>
-              {tech}
-            </Tag>
-          )) : <></>}
+            <Column className='icon__column' lg={1}><Enterprise className="enterprise_icon"/></Column>
+            <Column className='tag__column'><Tag className="projectTile__industry" type="cyan" key={index}>{repo.industry}</Tag></Column>
+          </Row>
+          <Row className="project__row">
+          <Column className='icon__column' lg={1}><ToolKit className="toolkit_icon"/></Column>
+          <Column className='tag__column'>{ Object.hasOwn(repo, "technology") ? 
+            repo.technology.map((tech, index) => (
+              <Tag className="projectTile__techs" type="blue" key={index}>
+                {tech}
+              </Tag>
+            )) : <></>}</Column>
           </Row>
 
         </ClickableTile> </Column>

--- a/src/app/home/_landing-page.scss
+++ b/src/app/home/_landing-page.scss
@@ -69,7 +69,7 @@
 }
 
 .clickable-tile-6 {
-  background: #F1C21B,
+  background: #9EF0F0,
 }
 .clickable-tile-6:hover {
   background: #f8e08d,

--- a/src/app/home/_landing-page.scss
+++ b/src/app/home/_landing-page.scss
@@ -88,3 +88,8 @@
 .subheading-text {
   padding-right: 30%;
 }
+
+.icon__column {
+  width: 32px;
+  padding-top: .5em;
+}

--- a/src/app/home/_landing-page.scss
+++ b/src/app/home/_landing-page.scss
@@ -72,7 +72,7 @@
   background: #9EF0F0,
 }
 .clickable-tile-6:hover {
-  background: #f8e08d,
+  background: #d0e4e4,
 }
 
 .projectTile-home {

--- a/src/app/projects/ProjectsTiles.js
+++ b/src/app/projects/ProjectsTiles.js
@@ -1,10 +1,11 @@
 'use client';
 import React from 'react';
-import { Launch, ToolKit } from '@carbon/icons-react';
+import { Launch, ToolKit, Enterprise } from '@carbon/icons-react';
 import {
   ClickableTile,
   Tag,
   Row,
+  Column
 } from "@carbon/react";
 
 const ProjectsTiles = ({ data }) => {
@@ -16,13 +17,17 @@ const ProjectsTiles = ({ data }) => {
           <p3 className="projectTile__industry">{repo.industry}</p3>
           <p3 className="projectTile__description">{repo.description}</p3>
           <Row className="project__row">
-          <ToolKit className="toolkit_icon"/>
-          { Object.hasOwn(repo, "technology") ? 
-          repo.technology.map((tech, index) => (
-            <Tag className="projectTile__techs" type="blue" key={index}>
-              {tech}
-            </Tag>
-          )) : <></>}
+            <Column className='icon__column' lg={1}><Enterprise className="enterprise_icon"/></Column>
+            <Column className='tag__column'><Tag className="projectTile__industry" type="cyan" key={index}>{repo.industry}</Tag></Column>
+          </Row>
+          <Row className="project__row">
+          <Column className='icon__column' lg={1}><ToolKit className="toolkit_icon"/></Column>
+          <Column className='tag__column'>{ Object.hasOwn(repo, "technology") ? 
+            repo.technology.map((tech, index) => (
+              <Tag className="projectTile__techs" type="blue" key={index}>
+                {tech}
+              </Tag>
+            )) : <></>}</Column>
           </Row>
         </ClickableTile>
       ))}

--- a/src/app/projects/ProjectsTiles.js
+++ b/src/app/projects/ProjectsTiles.js
@@ -14,7 +14,6 @@ const ProjectsTiles = ({ data }) => {
       {data.map((repo, index) => (
         <ClickableTile id={repo.name} className="projectTile" key={index} href={repo.homepageUrl} target="_blank" rel="noopener noreferrer" renderIcon={Launch}>
           <h6 className="projectTile__title">{repo.title}</h6>
-          <p3 className="projectTile__industry">{repo.industry}</p3>
           <p3 className="projectTile__description">{repo.description}</p3>
           <Row className="project__row">
             <Column className='icon__column' lg={1}><Enterprise className="enterprise_icon"/></Column>

--- a/src/app/projects/_projects-page.scss
+++ b/src/app/projects/_projects-page.scss
@@ -36,7 +36,6 @@
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(290px, 1fr));
     grid-template-rows: auto;
-    grid-gap: 1rem;
 }
 
 .projectTile {
@@ -69,7 +68,7 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-start;
-    gap: 16px;
+    gap: 2rem;
   }
 
 

--- a/src/app/projects/_projects-page.scss
+++ b/src/app/projects/_projects-page.scss
@@ -30,6 +30,7 @@
 
 .repoTiles{
     margin-bottom: 0;
+    margin-top: 3rem;
     height: auto;
     width: 100%;
     display: grid;
@@ -103,21 +104,28 @@
 }
 
 
-.filter-search {
-    width: 30%;
-}
-
 .banner-search {
-    width: 70%;
+    width: 100%;
 }
 
 .search-row {
-    width: 100%;
     padding-left: 1em;
+    display: flex;
 }
+
 .filter-row {
     width: 100%;
     padding-left: 1em;
 }
+.filter-search {
+    width: 100%;
+}
 
+.filters__col {
+    display: inline-block;
+    min-width: 20rem;
+}
 
+.search_projects__col {
+    display: inline-block;
+}

--- a/src/app/projects/_projects-page.scss
+++ b/src/app/projects/_projects-page.scss
@@ -41,8 +41,8 @@
 .projectTile {
     border: 1px solid var(--UI-ui-03, #E0E0E0);
     background: #FFF;
-    width: 300px;
-    height: 300px;
+    width: 350px;
+    height: 350px;
   }
 
 .projectTile__title {
@@ -53,15 +53,6 @@
     align-items: flex-start;
     gap: 8px;
     align-self: stretch;
-}
-
-.projectTile__industry {
-    display: flex;
-    //padding: 16px 16px 0px 0px;
-    flex-direction: column;
-    align-items: flex-start;
-    align-self: stretch;
-    font-style: italic;
 }
 
 .projectTile__description {
@@ -80,14 +71,21 @@
     gap: 16px;
   }
 
-.projectTile__techs {
-    font-weight: bold;
+
+.icon__column {
+    width: 16px;
+    margin-right: 0;
 }
+
+.tag__column {
+    width: 90%;
+    align-items: start;
+    margin-right: 0;
+}
+
 
 .project__row {
     padding: 0px 16px 0px 16px;
-    display: flex;
-    flex-wrap: wrap;
 }
 
 .toolkit_icon {
@@ -96,6 +94,14 @@
     margin-right: .5em;
     margin-left: 0px;
 }
+
+.enterprise_icon {
+    margin-top: auto;
+    margin-bottom: auto;
+    margin-right: .5em;
+    margin-left: 0px;
+}
+
 
 .filter-search {
     width: 30%;

--- a/src/app/projects/_projects-page.scss
+++ b/src/app/projects/_projects-page.scss
@@ -81,6 +81,7 @@
     width: 90%;
     align-items: start;
     margin-right: 0;
+    margin-left: .5em;
 }
 
 
@@ -91,7 +92,7 @@
 .toolkit_icon {
     margin-top: auto;
     margin-bottom: auto;
-    margin-right: .5em;
+    // margin-right: .5em;
     margin-left: 0px;
 }
 
@@ -127,4 +128,12 @@
 
 .search_projects__col {
     display: inline-block;
+}
+
+.projectTile__techs {
+    margin-left: 0;
+}
+
+.projectTile__industry {
+    margin-left: 0;
 }

--- a/src/app/projects/page.js
+++ b/src/app/projects/page.js
@@ -9,31 +9,34 @@ const repoData = data.organization.repositories.nodes.filter(repo => repo.publis
 // For checking if the repo falls under the current search or topic filters
 // It maps the repo name to an object that describes if it falls under the search filter and/or the topic .ilter
 const repoFiltered = new Map(); 
-const topics = new Set();
+const industries = new Set();
 const techs = new Set();
 repoData.forEach((node) => {
-  repoFiltered.set(node.name, { "topic": true, "search": true, "tech": true });
-  node.repositoryTopics.nodes.forEach((topic) => {
-    topics.add(topic.topic.name);
-  });
+  repoFiltered.set(node.name, { "industry": true, "search": true, "tech": true });
+  industries.add(node.industry);
   //if the object has a technology field, add it to the techs set
   Object.hasOwn(node, "technology") ? node.technology.forEach((tech) => {techs.add(tech);}) : {};
 });
 const techsArray = Array.from(techs);
+const industriesArray = Array.from(industries);
 
 // Parse URL parameters outside the component
 const urlParams = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null;
-const tech = urlParams ? urlParams.get('tech') : null;
+const industry = urlParams ? urlParams.get('industry') : null;
+const initialSelectedIndustries = industry ? [industry] : [];
+const tech = urlParams ? urlParams.get('industry') : null;
 const initialSelectedTechs = tech ? [tech] : [];
+
 
 function ProjectsPage() {
   const [selectedTechs, setSelectedTechs] = useState(initialSelectedTechs);
+  const [selectedIndustries, setSelectedIndustries] = useState(initialSelectedIndustries);
 
   // Define the renderProjects function, which updates the page based on the user inputted filters
   const renderProjects = () => {
     repoData.forEach((node) => {
       if (document.getElementById(node.name)) {
-        if (repoFiltered.get(node.name).topic && repoFiltered.get(node.name).search && repoFiltered.get(node.name).tech) {
+        if (repoFiltered.get(node.name).industry && repoFiltered.get(node.name).search && repoFiltered.get(node.name).tech) {
           document.getElementById(node.name).style.display = "block";
         } else {
           document.getElementById(node.name).style.display = "none";
@@ -81,7 +84,7 @@ function ProjectsPage() {
       const inputTechs = e.selectedItems;
       setSelectedTechs(inputTechs);
       repoData.forEach((node) => {
-        const nodeTechs = node.technology
+        const nodeTechs = node.technology;
         //Need to check that the repo has a technology field, and if it does need to check if the selected tech(s) is in that array
         //in the case where the repo has no techs listed, still needs to be true if there are no selected techs
         const inRepo =  inputTechs.every((tech) => Object.hasOwn(node, "technology") ? nodeTechs.includes(tech) : inputTechs.length == 0);
@@ -95,32 +98,75 @@ function ProjectsPage() {
       renderProjects();
     };
 
+    //callback function for the industry filter, filters the projects by the industries selected
+    const filterProjectsIndustry = (e) => {
+      const inputIndustries = e.selectedItems;
+      setSelectedIndustries(inputIndustries);
+      repoData.forEach((node) => {
+        const nodeIndustry = node.industry
+        //Need to check that the repo has an industry field (it should), and if it does need to check if the selected industry/industries match
+        //in the case where the repo has no industry listed, still needs to be true if there are no selected techs
+        const inRepo =  inputIndustries.some((industry) => Object.hasOwn(node, "industry") ? nodeIndustry === industry : inputIndustries.length == 0);
+
+        if (document.getElementById(node.name)) {
+          const temp = repoFiltered.get(node.name);
+          temp.industry = inputIndustries.length > 0 ? inRepo : true;
+          repoFiltered.set(node.name, temp);
+        }
+      });
+      renderProjects();
+    };
+
   return (
     <Grid fullWidth narrow>
-      <Column className="banner-container" lg={16} md={8} sm={4}>
-        <Column className="banner-title-container" lg={8} md={4} sm={2}>
+      <Column className="banner-container" lg={16} md={8} sm={4}> {/*lg={16} md={8} sm={4}*/}
+        <Column className="banner-title-container" lg={8} md={4} sm={2}> {/*lg={8} md={4} sm={2}*/}
           <p className="banner-title">Projects</p>
-          <Row className='search-row'>
-            <Search className="banner-search" size="lg" placeholder="Search" labelText="Search" closeButtonLabelText="Clear search input" onChange={searchProjects} />
-            <FilterableMultiSelect 
-              id="carbon-multiselect" 
-              className="filter-search" 
-              size="lg" 
-              placeholder="Technology" 
-              items={techsArray} 
-              itemToString={item => item ? item : ''} 
-              selectionFeedback="top-after-reopen" 
-              onChange={filterProjectsTech} 
-              initialSelectedItems={selectedTechs} // Set selected items based on state
+        </Column>
+        <Column className="banner-image-container" lg={8} md={4} sm={2}></Column>
+      </Column>
+      <Column className='search-row' lg={16} md={8} sm={4}>
+        <Column className="filters__col">
+          <Column>
+          <FilterableMultiSelect 
+            id="carbon-multiselect" 
+            className="filter-search" 
+            size="lg" 
+            placeholder="Industry" 
+            items={industriesArray} 
+            itemToString={item => item ? item : ''} 
+            selectionFeedback="top-after-reopen" 
+            onChange={filterProjectsIndustry} 
+            initialSelectedItems={selectedIndustries} // Set selected items based on state
+          />
+          </Column>
+          <Column>
+          <FilterableMultiSelect 
+            id="carbon-multiselect" 
+            className="filter-search" 
+            size="lg" 
+            placeholder="Technology" 
+            items={techsArray} 
+            itemToString={item => item ? item : ''} 
+            selectionFeedback="top-after-reopen" 
+            onChange={filterProjectsTech} 
+            initialSelectedItems={selectedTechs} // Set selected items based on state
             />
-          </Row>
+          </Column>
         </Column>
-        <Column className="banner-image-container" lg={8} md={4} sm={2}>
+        
+        <Column className="search_projects__col">
+          <Column>
+            <Search className="banner-search" size="lg" placeholder="Search" labelText="Search" closeButtonLabelText="Clear search input" onChange={searchProjects} />
+          </Column>
+          <Column className="repoTiles">
+            <ProjectsTiles data={repoData}></ProjectsTiles>
+          </Column>
+
         </Column>
       </Column>
-      <Column lg={16} md={8} sm={2} className="repoTiles">
-        <ProjectsTiles data={repoData}></ProjectsTiles>
-      </Column>
+        
+
     </Grid>
   );
 }

--- a/src/components/CarbonHeader/CarbonHeader.js
+++ b/src/components/CarbonHeader/CarbonHeader.js
@@ -8,33 +8,40 @@ import {
     HeaderGlobalAction,
     SkipToContent,
   } from '@carbon/react';
-import { Search } from '@carbon/icons-react';
 import Link from 'next/link';
-  
-  const CarbonHeader = () => (
-    <HeaderContainer
-      render={({}) => (
-        <Header aria-label="Solutions Hub">
-          <SkipToContent />
-          <Link href="/" passHref legacyBehavior>
-            <HeaderName prefix="IBM">
-              Client Engineering Solutions Hub
-            </HeaderName>
-          </Link>
-          <HeaderNavigation aria-label="Solutions Hub">
-          <Link href="/projects" passHref legacyBehavior>
-            <HeaderMenuItem>Projects</HeaderMenuItem>
-          </Link>  
-          <Link href="/mission" passHref legacyBehavior>
-            <HeaderMenuItem>Mission</HeaderMenuItem>
-          </Link>
-          </HeaderNavigation>
-        </Header>
-      )}
-    />
-  );
-  
-  export default CarbonHeader;
+import { useState, useEffect } from 'react';
+
+
+const CarbonHeader = () => {
+  const [page, setPage] = useState(typeof window !== 'undefined' ? window.location.pathname: "/")
+  return (
+  <HeaderContainer
+    render={({}) => (
+      <Header aria-label="Solutions Hub">
+        <SkipToContent />
+        <Link href="/" passHref legacyBehavior>
+          <HeaderName prefix="IBM" onClick={() => setPage("/ce-solutions-hub")}>
+            Client Engineering Solutions Hub
+          </HeaderName>
+        </Link>
+        <HeaderNavigation aria-label="Solutions Hub">
+        <Link href="/" passHref legacyBehavior>
+          <HeaderMenuItem isActive={page === "/ce-solutions-hub"} onClick={() => setPage("/ce-solutions-hub")}>Home</HeaderMenuItem>
+        </Link>
+        <Link href="/projects" passHref legacyBehavior>
+          <HeaderMenuItem isActive={page === "/ce-solutions-hub/projects"} onClick={() => setPage("/ce-solutions-hub/projects")}>Projects</HeaderMenuItem>
+        </Link>  
+        <Link href="/mission" passHref legacyBehavior>
+          <HeaderMenuItem isActive={page === "/ce-solutions-hub/mission"} onClick={() => setPage("/ce-solutions-hub/mission")}>Mission</HeaderMenuItem>
+        </Link>
+        </HeaderNavigation>
+      </Header>
+    )}
+  />
+  )
+};
+
+export default CarbonHeader;
 
 /*
           <Link href="/methodology" passHref legacyBehavior>


### PR DESCRIPTION
Updated the frontend according to [Dipti's redesign](https://www.figma.com/design/Hm2STS52P5ObCkmpTnYcPI/Solutions-Hub-Design).

5 main changes:

1. Blue bar to indicate which page you are on (and a new home option)
2. Industry listed as a tag
3. Industry and technologies moved to the left side of the projects page
4. Changed color for the Z tile on the main page
5. Increased spacing of the projects on the projects page

Home Page:
<img width="1544" alt="Screenshot 2024-11-13 at 4 37 54 PM" src="https://github.com/user-attachments/assets/79d8ee32-7e84-48be-ba64-2ddb5c5120da">

Projects Page:
<img width="1546" alt="Screenshot 2024-11-13 at 4 38 01 PM" src="https://github.com/user-attachments/assets/4723e357-1275-4a73-8317-b8698da7f94f">


I was unable to get the icons for technology and industry into their respective filter bars, unsure if this is possible.
